### PR TITLE
Support disconnect

### DIFF
--- a/src/InputStream.c
+++ b/src/InputStream.c
@@ -393,11 +393,15 @@ int stopInputStream(void) {
     LbqSignalQueueShutdown(&packetQueue);
     PltInterruptThread(&inputSendThread);
 
+
+    if (inputSock != INVALID_SOCKET) {
+        shutdownTcpSocket(inputSock);
+    }
+
     PltJoinThread(&inputSendThread);
     PltCloseThread(&inputSendThread);
 
     if (inputSock != INVALID_SOCKET) {
-        shutdownTcpSocket(inputSock);
         closeSocket(inputSock);
         inputSock = INVALID_SOCKET;
     }

--- a/src/InputStream.c
+++ b/src/InputStream.c
@@ -393,14 +393,11 @@ int stopInputStream(void) {
     LbqSignalQueueShutdown(&packetQueue);
     PltInterruptThread(&inputSendThread);
 
-    if (inputSock != INVALID_SOCKET) {
-        shutdownTcpSocket(inputSock);
-    }
-
     PltJoinThread(&inputSendThread);
     PltCloseThread(&inputSendThread);
-    
+
     if (inputSock != INVALID_SOCKET) {
+        shutdownTcpSocket(inputSock);
         closeSocket(inputSock);
         inputSock = INVALID_SOCKET;
     }

--- a/src/Platform.c
+++ b/src/Platform.c
@@ -162,6 +162,10 @@ int PltCreateThread(ThreadEntry entry, void* context, PLT_THREAD* thread) {
         thread->context = ctx;
         ctx->thread = thread;
         thread->handle = sceKernelCreateThread("", ThreadProc, 0, 0x10000, 0, 0, NULL);
+        if (thread->handle < 0) {
+            free(ctx);
+            return -1;
+        }
         sceKernelStartThread(thread->handle, sizeof(struct thread_context), ctx);
     }
 #elif defined(LC_WINDOWS)

--- a/src/PlatformThreads.h
+++ b/src/PlatformThreads.h
@@ -15,6 +15,8 @@ typedef struct _PLT_EVENT {
 typedef struct _PLT_THREAD {
     int handle;
     int cancelled;
+    void *context;
+    int alive;
 } PLT_THREAD;
 #elif defined(LC_WINDOWS)
 typedef HANDLE PLT_MUTEX;

--- a/src/VideoStream.c
+++ b/src/VideoStream.c
@@ -163,6 +163,10 @@ void stopVideoStream(void) {
         PltInterruptThread(&decoderThread);
     }
 
+    if (firstFrameSocket != INVALID_SOCKET) {
+        shutdownTcpSocket(firstFrameSocket);
+    }
+
     PltJoinThread(&udpPingThread);
     PltJoinThread(&receiveThread);
     if ((VideoCallbacks.capabilities & CAPABILITY_DIRECT_SUBMIT) == 0) {
@@ -176,7 +180,6 @@ void stopVideoStream(void) {
     }
     
     if (firstFrameSocket != INVALID_SOCKET) {
-        shutdownTcpSocket(firstFrameSocket);
         closeSocket(firstFrameSocket);
         firstFrameSocket = INVALID_SOCKET;
     }

--- a/src/VideoStream.c
+++ b/src/VideoStream.c
@@ -163,10 +163,6 @@ void stopVideoStream(void) {
         PltInterruptThread(&decoderThread);
     }
 
-    if (firstFrameSocket != INVALID_SOCKET) {
-        shutdownTcpSocket(firstFrameSocket);
-    }
-
     PltJoinThread(&udpPingThread);
     PltJoinThread(&receiveThread);
     if ((VideoCallbacks.capabilities & CAPABILITY_DIRECT_SUBMIT) == 0) {
@@ -180,6 +176,7 @@ void stopVideoStream(void) {
     }
     
     if (firstFrameSocket != INVALID_SOCKET) {
+        shutdownTcpSocket(firstFrameSocket);
         closeSocket(firstFrameSocket);
         firstFrameSocket = INVALID_SOCKET;
     }


### PR DESCRIPTION
in my test, cannot free ctx in thread, it cause crash about `0x30004 Data abort exception`.
- add state flag fields
- now `PltJoinThread` use manually waiting method instead `sceKernelWaitThreadEnd`. this method wait to change state flag, then free context object.
